### PR TITLE
Add Ethernet as new BaseLayer

### DIFF
--- a/gowireshark_test.go
+++ b/gowireshark_test.go
@@ -169,6 +169,27 @@ func TestParseCustomProtocol(t *testing.T) {
 }
 
 /*
+Parse Ethernet
+*/
+func TestParseEth(t *testing.T) {
+	pcapPath := "./pcaps/https.pcapng"
+	frame, err := GetFrameByIdx(pcapPath, 14, PrintCJson(true), WithDebug(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log("# Frame index:", frame.BaseLayers.Frame.Number, "===========================")
+	t.Log("【layer _ws.col.protocol】:", frame.BaseLayers.WsCol.Protocol)
+
+	if frame.BaseLayers.Eth != nil {
+		t.Log("## eth.src:", frame.BaseLayers.Eth.Src)
+		t.Log("## eth.dst:", frame.BaseLayers.Eth.Dst)
+	} else {
+		t.Error("fail to parse tls!")
+	}
+}
+
+/*
 DEMO: parse SSLv1.2
 */
 func TestParseHttps(t *testing.T) {

--- a/layers.go
+++ b/layers.go
@@ -23,6 +23,7 @@ type FrameData struct {
 	BaseLayers struct { // common layers
 		Frame *Frame
 		WsCol *WsCol
+		Eth   *Eth
 		Ip    *Ip
 		Udp   *Udp
 		Tcp   *Tcp
@@ -205,6 +206,79 @@ func (l Layers) WsCol() (wsCol any, err error) {
 		Protocol:  tmp.Protocol,
 		PacketLen: packetLen,
 		Info:      tmp.Info,
+	}, nil
+}
+
+// Eth Wireshark ETH layer structure (frame.eth)
+type Eth struct {
+	Src            string `json:"eth.src"`
+	SrcResolved    string `json:"eth.src_tree.addr_resolved"`
+	SrcOui         int    `json:"eth.src_tree.addr.oui"`
+	SrcOuiResolved string `json:"eth.src_tree.addr.oui_resolved"`
+	SrcIG          int    `json:"eth.src_tree.ig"`
+	SrcLG          int    `json:"eth.src_tree.lg"`
+	Dst            string `json:"eth.dst"`
+	DstResolved    string `json:"eth.dst_tree.addr_resolved"`
+	DstOui         int    `json:"eth.dst_tree.addr.oui"`
+	DstOuiResolved string `json:"eth.dst_tree.addr.oui_resolved"`
+	DstIG          int    `json:"eth.dst_tree.ig"`
+	DstLG          int    `json:"eth.dst_tree.lg"`
+	Type           string `json:"eth.type"`
+}
+
+func (l Layers) Eth() (eth any, err error) {
+	src, ok := l["eth"]
+	if !ok {
+		return nil, errors.Wrap(ErrLayerNotFound, "eth")
+	}
+	type tmpEth struct {
+		Src            string `json:"eth.src"`
+		SrcResolved    string `json:"eth.src_tree.addr_resolved"`
+		SrcOui         string `json:"eth.src_tree.addr.oui"`
+		SrcOuiResolved string `json:"eth.src_tree.addr.oui_resolved"`
+		SrcIG          string `json:"eth.src_tree.ig"`
+		SrcLG          string `json:"eth.src_tree.lg"`
+		Dst            string `json:"eth.dst"`
+		DstResolved    string `json:"eth.dst_tree.addr_resolved"`
+		DstOui         string `json:"eth.dst_tree.addr.oui"`
+		DstOuiResolved string `json:"eth.dst_tree.addr.oui_resolved"`
+		DstIG          string `json:"eth.dst_tree.ig"`
+		DstLG          string `json:"eth.dst_tree.lg"`
+		Type           string `json:"eth.type"`
+	}
+	var tmp tmpEth
+
+	jsonData, err := json.Marshal(src)
+	if err != nil {
+		return nil, errors.Wrapf(err, "eth: %s", ErrParseFrame)
+	}
+
+	err = json.Unmarshal(jsonData, &tmp)
+	if err != nil {
+		return nil, errors.Wrapf(err, "eth: %s", ErrParseFrame)
+	}
+
+	srcOui, err := strconv.Atoi(tmp.SrcOui)
+	srcIG, err := strconv.Atoi(tmp.SrcIG)
+	srcLG, err := strconv.Atoi(tmp.SrcLG)
+	dstOui, err := strconv.Atoi(tmp.DstOui)
+	dstIG, err := strconv.Atoi(tmp.DstIG)
+	dstLG, err := strconv.Atoi(tmp.DstLG)
+
+	return &Eth{
+		Src:            tmp.Src,
+		SrcResolved:    tmp.SrcResolved,
+		SrcOui:         srcOui,
+		SrcOuiResolved: tmp.SrcOuiResolved,
+		SrcIG:          srcIG,
+		SrcLG:          srcLG,
+		Dst:            tmp.Dst,
+		DstResolved:    tmp.DstResolved,
+		DstOui:         dstOui,
+		DstOuiResolved: tmp.DstOuiResolved,
+		DstIG:          dstIG,
+		DstLG:          dstLG,
+		Type:           tmp.Type,
 	}, nil
 }
 

--- a/offline.go
+++ b/offline.go
@@ -191,7 +191,7 @@ func ParseFrameData(src string) (frame *FrameData, err error) {
 		}
 	}
 
-	wg.Add(7)
+	wg.Add(8)
 
 	go parseAndSetLayer(frame.Layers.WsCol, func(layer any) {
 		frame.BaseLayers.WsCol = layer.(*WsCol)
@@ -199,6 +199,10 @@ func ParseFrameData(src string) (frame *FrameData, err error) {
 
 	go parseAndSetLayer(frame.Layers.Frame, func(layer any) {
 		frame.BaseLayers.Frame = layer.(*Frame)
+	})
+
+	go parseAndSetLayer(frame.Layers.Eth, func(layer any) {
+		frame.BaseLayers.Eth = layer.(*Eth)
 	})
 
 	go parseAndSetLayer(frame.Layers.Ip, func(layer any) {


### PR DESCRIPTION
This PR adds Ethernet as a new BaseLayer for all frames.

```go
type Eth struct {
	Src            string `json:"eth.src"`
	SrcResolved    string `json:"eth.src_tree.addr_resolved"`
	SrcOui         int    `json:"eth.src_tree.addr.oui"`
	SrcOuiResolved string `json:"eth.src_tree.addr.oui_resolved"`
	SrcIG          int    `json:"eth.src_tree.ig"`
	SrcLG          int    `json:"eth.src_tree.lg"`
	Dst            string `json:"eth.dst"`
	DstResolved    string `json:"eth.dst_tree.addr_resolved"`
	DstOui         int    `json:"eth.dst_tree.addr.oui"`
	DstOuiResolved string `json:"eth.dst_tree.addr.oui_resolved"`
	DstIG          int    `json:"eth.dst_tree.ig"`
	DstLG          int    `json:"eth.dst_tree.lg"`
	Type           string `json:"eth.type"`
}
```

Also added a new test: `go test -run TestParseEth`